### PR TITLE
chore: Add Shellcheck commands GitHub Actions

### DIFF
--- a/.github/workflows/static-analysis.yml
+++ b/.github/workflows/static-analysis.yml
@@ -3,6 +3,7 @@ on:
   pull_request:
     paths:
       - '**.sh'
+  workflow_dispatch:
 jobs:
   shellcheck:
     runs-on: ubuntu-latest

--- a/.github/workflows/static-analysis.yml
+++ b/.github/workflows/static-analysis.yml
@@ -12,4 +12,6 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - name: Run Shellcheck
-        run: shellcheck *.sh
+        run: |
+          shopt -s nullglob dotglob
+          shellcheck **.sh

--- a/.github/workflows/static-analysis.yml
+++ b/.github/workflows/static-analysis.yml
@@ -1,8 +1,5 @@
 name: Static Analysis for Commands
 on:
-  push:
-    branches:
-      - chore/add-shellcheck-github-actions
   pull_request:
     paths:
       - 'commands/**.sh'

--- a/.github/workflows/static-analysis.yml
+++ b/.github/workflows/static-analysis.yml
@@ -1,0 +1,12 @@
+name: Static Analysis
+on:
+  pull_request:
+    paths:
+      - '**.sh'
+jobs:
+  shellcheck:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Run Shellcheck
+        run: shellcheck *.sh

--- a/.github/workflows/static-analysis.yml
+++ b/.github/workflows/static-analysis.yml
@@ -1,13 +1,11 @@
 name: Static Analysis
 on:
+  push:
+    branches:
+      - chore/add-shellcheck-github-actions
   pull_request:
     paths:
       - '**.sh'
-  workflow_dispatch:
-    inputs:
-      exam:
-        description: 'trial'
-        required: false
 jobs:
   shellcheck:
     runs-on: ubuntu-latest

--- a/.github/workflows/static-analysis.yml
+++ b/.github/workflows/static-analysis.yml
@@ -1,17 +1,17 @@
-name: Static Analysis
+name: Static Analysis for Commands
 on:
   push:
     branches:
       - chore/add-shellcheck-github-actions
   pull_request:
     paths:
-      - '**.sh'
+      - 'commands/**.sh'
 jobs:
-  shellcheck:
+  lint-commands:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - name: Run Shellcheck
+      - name: Shellcheck for commands
         run: |
           shopt -s nullglob dotglob
-          shellcheck **.sh
+          shellcheck commands/**.sh

--- a/.github/workflows/static-analysis.yml
+++ b/.github/workflows/static-analysis.yml
@@ -4,6 +4,10 @@ on:
     paths:
       - '**.sh'
   workflow_dispatch:
+    inputs:
+      exam:
+        description: 'trial'
+        required: false
 jobs:
   shellcheck:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Description

Add Shellcheck GitHub Actions, because of Raycast official recommendation.

> we highly recommend using the [Shellcheck](https://marketplace.visualstudio.com/items?itemName=timonwong.shellcheck) linter as this will ensure smooth running of your script. All scripts uploaded to GitHub will need to have been run through ShellCheck.

See: [raycast/script-commands>README>Create your own Script Commands](https://github.com/raycast/script-commands?tab=readme-ov-file#create-your-own-script-commands)

- This PR only supports the `commands` directory scope.
- Existing .sh files have already been validated.

### FYI

- https://github.com/koalaman/shellcheck
- [ShellCheck: Recursiveness](https://www.shellcheck.net/wiki/Recursiveness)

## Type of change

- [x] Other (Add GitHub Actions)
